### PR TITLE
Fix to Issue #14680

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -42,7 +42,7 @@ var v = "Hi! I'm a strict mode script!";
 Likewise, to invoke strict mode for a function, put the _exact_ statement `"use strict";` (or `'use strict';`) in the function's body before any other statements.
 
 ```js
-function strict() {
+function strictFunction() {
   // Function-level strict mode syntax
   'use strict';
   function nested() { return 'And so am I!'; }
@@ -58,10 +58,10 @@ In strict mode, starting with ES2015, functions inside blocks are scoped to that
 ECMAScript 2015 introduced [JavaScript modules](/en-US/docs/Web/JavaScript/Reference/Statements/export) and therefore a 3rd way to enter strict mode. The entire contents of JavaScript modules are automatically in strict mode, with no statement needed to initiate it.
 
 ```js
-function strict() {
+function strictFunction() {
     // because this is a module, I'm strict by default
 }
-export default strict;
+export default strictFunction;
 ```
 
 ### Strict mode for classes
@@ -74,9 +74,9 @@ Strict mode changes both syntax and runtime behavior. Changes generally fall int
 
 ### Converting mistakes into errors
 
-Strict mode changes some previously-accepted mistakes into errors. JavaScript was designed to be easy for novice developers, and sometimes it gives operations which should be errors non-error semantics. Sometimes this fixes the immediate problem, but sometimes this creates worse problems in the future. Strict mode treats these mistakes as errors so that they're discovered and promptly fixed.
+Strict mode changes some previously-accepted mistakes into errors. JavaScript was designed to be easy for novice developers, and sometimes it gives non-error semantics to operations that should be errors. Sometimes this fixes the immediate problem, but sometimes this creates worse problems in the future. Strict mode treats these mistakes as errors so that they're discovered and promptly fixed.
 
-First, strict mode makes it impossible to accidentally create global variables. In normal JavaScript mistyping a variable in an assignment creates a new property on the global object and continues to "work" (although future failure is possible: likely, in modern JavaScript). Assignments, which would accidentally create global variables, instead throw an error in strict mode:
+First, strict mode makes it impossible to accidentally create global variables. In normal JavaScript, mistyping a variable in an assignment creates a new property on the global object and continues to "work" (however, future failure is possible; in modern JavaScript, it's likely). Assignments that would accidentally create global variables, instead throw an error in strict mode:
 
 ```js
 'use strict';
@@ -87,14 +87,14 @@ mistypeVarible = 17;  // Assuming no global variable mistypeVarible exists
                       // misspelling of "mistypeVariable" (lack of an "a")
 ```
 
-Second, strict mode makes assignments which would otherwise silently fail to throw an exception. For example, `NaN` is a non-writable global variable. In normal code assigning to `NaN` does nothing; the developer receives no failure feedback. In strict mode assigning to `NaN` throws an exception. Any assignment that silently fails in normal code (assignment to a non-writable global or property, assignment to a getter-only property, assignment to a new property on a [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) object) will throw in strict mode:
+Second, strict mode causes assignments that would otherwise silently fail, to throw an exception instead. For example, `NaN` is a non-writable global variable. In normal code, assigning to `NaN` does nothing; the developer receives no failure feedback. In strict mode assigning to `NaN` throws an exception. Any assignment that silently fails in normal code (such as assignment to a non-writable global or property, assignment to a getter-only property, assignment to a new property on a [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) object)  throws an error in strict mode:
 
 ```js
 'use strict';
 
 // Assignment to a non-writable global
 var undefined = 5; // throws a TypeError
-var Infinity = 5; // throws a TypeError
+var Infinity = 5;  // throws a TypeError
 
 // Assignment to a non-writable property
 var obj1 = {};
@@ -111,14 +111,14 @@ Object.preventExtensions(fixed);
 fixed.newProp = 'ohai'; // throws a TypeError
 ```
 
-Third, strict mode makes attempts to delete undeletable properties throw (where before the attempt would have no effect):
+Third, strict mode makes errors be thrown on attempts to delete undeletable properties (whereas otherwise the attempt would have no effect):
 
 ```js
 'use strict';
 delete Object.prototype; // throws a TypeError
 ```
 
-Fourth, strict mode requires that function parameter names be unique. In normal code the last duplicated argument hides previous identically-named arguments. Those previous arguments remain available through `arguments[i]`, so they're not completely inaccessible. Still, this hiding makes little sense and is probably undesirable (it might hide a typo, for example), so in strict mode duplicate argument names are a syntax error:
+Fourth, strict mode requires that function parameter names be unique. In normal code, the last duplicated argument hides previous identically-named arguments. Those previous arguments remain available through `arguments[i]`, so they're not completely inaccessible. Still, this hiding makes little sense and is probably undesirable (it might hide a typo, for example), so in strict mode duplicate argument names are a syntax error:
 
 ```js
 function sum(a, a, c) { // !!! syntax error
@@ -127,13 +127,13 @@ function sum(a, a, c) { // !!! syntax error
 }
 ```
 
-Fifth, a strict mode in ECMAScript 5 [forbids a `0`-prefixed octal literal or octal escape sequence](/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal). Outside strict mode, a number beginning with a `0`, such as `0644`, is interpreted as an octal number (`0644 === 420`), if all digits are smaller than 8. Octal escape sequences, such as `"\45"`, which is equal to `"%"`, can be used to represent characters by extended-ASCII character code numbers in octal. In strict mode, this is a syntax error. In ECMAScript 2015, octal literals are supported by prefixing a number with "`0o`"; for example:
+Fifth, a strict mode in ECMAScript 5 [forbids a `0`-prefixed octal literal or octal escape sequence](/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal). Outside strict mode, a number beginning with a `0`, such as `0644`, is interpreted as an octal number (`0644 === 420`), if all digits are less than 8. Octal escape sequences, such as `"\45"`, which is equal to `"%"`, can be used to represent characters by extended-ASCII character code numbers in octal. In strict mode, this is a syntax error. In ECMAScript 2015, octal literals are supported by prefixing a number with "`0o`"; for example:
 
 ```js
 var a = 0o10; // ES2015: Octal
 ```
 
-Novice developers sometimes believe a leading zero prefix has no semantic meaning, so they might use it as an alignment device — but this changes the number's meaning! A leading zero syntax for the octal is rarely useful and can be mistakenly used, so strict mode makes it a syntax error:
+Novice developers sometimes believe a leading zero prefix has no semantic meaning, so they might use it as an alignment device. However, doing this changes the number's meaning! A leading zero syntax for the octal is rarely useful and can be mistakenly used, so strict mode makes it a syntax error:
 
 ```js
 'use strict';
@@ -145,15 +145,15 @@ var sumWithOctal = 0o10 + 8;
 console.log(sumWithOctal); // 16
 ```
 
-Sixth, strict mode in ECMAScript 2015 forbids setting properties on [primitive](/en-US/docs/Glossary/Primitive) values. Without strict mode, setting properties is ignored (no-op), with strict mode, however, a {{jsxref("TypeError")}} is thrown.
+Sixth, strict mode in ECMAScript 2015 forbids setting properties on [primitive](/en-US/docs/Glossary/Primitive) values. Without strict mode, setting properties is ignored (no-op); with strict mode, however, a {{jsxref("TypeError")}} is thrown.
 
 ```js
 (function() {
 'use strict';
 
-false.true = '';         // TypeError
-(14).sailing = 'home';   // TypeError
-'with'.you = 'far away'; // TypeError
+false.true = '';         // throws a TypeError
+(14).sailing = 'home';   // throws a TypeError
+'with'.you = 'far away'; // throws a TypeError
 
 })();
 ```
@@ -169,7 +169,7 @@ var o = { p: 1, p: 2 }; // syntax error prior to ECMAScript 2015
 
 Strict mode simplifies how variable names map to particular variable definitions in the code. Many compiler optimizations rely on the ability to say that variable _X_ is stored in _that_ location: this is critical to fully optimizing JavaScript code. JavaScript sometimes makes this basic mapping of name to variable definition in the code impossible to perform until runtime. Strict mode removes most cases where this happens, so the compiler can better optimize strict mode code.
 
-First, strict mode prohibits [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with). The problem with `with` is that any name inside the block might map either to a property of the object passed to it, or to a variable in surrounding (or even global) scope, at runtime; it's impossible to know which beforehand. Strict mode makes `with` a syntax error, so there's no chance for a name in a `with` to refer to an unknown location at runtime:
+First, strict mode prohibits [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with). The problem with `with` is that any name inside the block might map either to a property of the object passed to it, or to a variable in surrounding (or even global) scope, at runtime; it's impossible to know which beforehand. Strict mode makes `with` a syntax error, so there's no chance for a name in a `with` block to refer to an unknown location at runtime:
 
 ```js
 'use strict';
@@ -185,7 +185,7 @@ with (obj) { // !!! syntax error
 
 The simple alternative of assigning the object to a short name variable, then accessing the corresponding property on that variable, stands ready to replace `with`.
 
-Second, [`eval` of strict mode code does not introduce new variables into the surrounding scope](https://whereswalden.com/2011/01/10/new-es5-strict-mode-support-new-vars-created-by-strict-mode-eval-code-are-local-to-that-code-only/). In normal code `eval("var x;")` introduces a variable `x` into the surrounding function or the global scope. This means that, in general, in a function containing a call to `eval` every name not referring to an argument or local variable must be mapped to a particular definition at runtime (because that `eval` might have introduced a new variable that would hide the outer variable). In strict mode `eval` creates variables only for the code being evaluated, so `eval` can't affect whether a name refers to an outer variable or some local variable:
+Second, [`eval` of strict mode code does not introduce new variables into the surrounding scope](https://whereswalden.com/2011/01/10/new-es5-strict-mode-support-new-vars-created-by-strict-mode-eval-code-are-local-to-that-code-only/). In normal code `eval("var x;")` introduces a variable `x` into the surrounding function or the global scope. This means that, in general, in a function containing a call to `eval`, every name not referring to an argument or a local variable must be mapped to a particular definition at runtime (because that `eval` might have introduced a new variable that would hide the outer variable). In strict mode, `eval` creates variables only for the code being evaluated, so `eval` can't affect whether a name refers to an outer variable or some local variable:
 
 ```js
 var x = 17;
@@ -194,34 +194,34 @@ console.assert(x === 17);
 console.assert(evalX === 42);
 ```
 
-If the function `eval` is invoked by an expression of the form `eval(...)` in strict mode code, the code will be evaluated as strict mode code. The code may explicitly invoke strict mode, but it's unnecessary to do so.
+If the function `eval` is invoked by an expression of the form `eval(...)` in strict mode code, the code is evaluated as strict mode code. The code may explicitly invoke strict mode, but it's unnecessary to do so.
 
 ```js
-function strict1(str) {
+function strictFunction1(str) {
   'use strict';
-  return eval(str); // str will be treated as strict mode code
+  return eval(str); // str is treated as strict mode code
 }
-function strict2(f, str) {
+function strictFunction2(f, str) {
   'use strict';
   return f(str); // not eval(...): str is strict if and only
                  // if it invokes strict mode
 }
-function nonstrict(str) {
+function nonStrict(str) {
   return eval(str); // str is strict if and only
                     // if it invokes strict mode
 }
 
-strict1("'Strict mode code!'");
-strict1("'use strict'; 'Strict mode code!'");
-strict2(eval, "'Non-strict code.'");
-strict2(eval, "'use strict'; 'Strict mode code!'");
-nonstrict("'Non-strict code.'");
-nonstrict("'use strict'; 'Strict mode code!'");
+strictFunction1("'Strict mode code!'");
+strictFunction1("'use strict'; 'Strict mode code!'");
+strictFunction2(eval, "'Non-strict code.'");
+strictFunction2(eval, "'use strict'; 'Strict mode code!'");
+nonStrict("'Non-strict code.'");
+nonStrict("'use strict'; 'Strict mode code!'");
 ```
 
-Thus names in strict mode `eval` code behave identically to names in strict mode code not being evaluated as the result of `eval`.
+Thus, names in strict mode `eval` code behave identically to names in strict mode code not being evaluated as the result of `eval`.
 
-Third, strict mode forbids deleting plain names. `delete name` in strict mode is a syntax error:
+Third, strict mode forbids deleting plain names. To say `delete name` in strict mode is a syntax error:
 
 ```js
 'use strict';
@@ -236,7 +236,7 @@ eval('var y; delete y;'); // !!! syntax error
 
 Strict mode makes `arguments` and `eval` less bizarrely magical. Both involve a considerable amount of magical behavior in normal code: `eval` to add or remove bindings and to change binding values, and `arguments` by its indexed properties aliasing named arguments. Strict mode makes great strides toward treating `eval` and `arguments` as keywords, although full fixes will not come until a future edition of ECMAScript.
 
-First, the names `eval` and `arguments` can't be bound or assigned in language syntax. All these attempts to do so are syntax errors:
+First, the names `eval` and `arguments` can't be bound or assigned in language syntax. All the following attempts to do so are syntax errors:
 
 ```js
 'use strict';
@@ -252,20 +252,20 @@ var y = function eval() { };
 var f = new Function('arguments', "'use strict'; return 17;");
 ```
 
-Second, strict mode code doesn't alias properties of `arguments` objects created within it. In normal code within a function whose first argument is `arg`, setting `arg` also sets `arguments[0]`, and vice versa (unless no arguments were provided or `arguments[0]` is deleted). `arguments` objects for strict mode functions store the original arguments when the function was invoked. `arguments[i]` does not track the value of the corresponding named argument, nor does a named argument track the value in the corresponding `arguments[i]`.
+Second, strict mode code doesn't alias properties of `arguments` objects created within it. In non-strict code, within a function whose first argument is `arg`, setting `arg` also sets `arguments[0]`, and vice versa (unless no arguments were provided or `arguments[0]` is deleted). The `arguments` objects for strict mode functions store the original arguments when the function was invoked. `arguments[i]` does not track the value of the corresponding named argument, nor does a named argument track the value in the corresponding `arguments[i]`.
 
 ```js
-function f(a) {
+function myFunc(a) {
   'use strict';
   a = 42;
   return [a, arguments[0]];
 }
-var pair = f(17);
+var pair = myFunc(17);
 console.assert(pair[0] === 42);
 console.assert(pair[1] === 17);
 ```
 
-Third, `arguments.callee` is no longer supported. In normal code `arguments.callee` refers to the enclosing function. This use case is weak: name the enclosing function! Moreover, `arguments.callee` substantially hinders optimizations like inlining functions, because it must be made possible to provide a reference to the un-inlined function if `arguments.callee` is accessed. `arguments.callee` for strict mode functions is a non-deletable property which throws an error when set or retrieved:
+Third, `arguments.callee` is no longer supported. In non-strict code, `arguments.callee` refers to the enclosing function. This use case is weak: name the enclosing function! Moreover, `arguments.callee` substantially hinders optimizations like inlining functions, because it must be made possible to provide a reference to the un-inlined function if `arguments.callee` is accessed. `arguments.callee` for strict mode functions is a non-deletable property that throws an error when set or retrieved:
 
 ```js
 'use strict';
@@ -275,9 +275,15 @@ f(); // throws a TypeError
 
 ### "Securing" JavaScript
 
-Strict mode makes it easier to write "secure" JavaScript. Some websites now provide ways for users to write JavaScript which will be run by the website _on behalf of other users_. JavaScript in browsers can access the user's private information, so such JavaScript must be partially transformed before it is run, to censor access to forbidden functionality. JavaScript's flexibility makes it effectively impossible to do this without many runtime checks. Certain language functions are so pervasive that performing runtime checks has a considerable performance cost. A few strict mode tweaks, plus requiring that user-submitted JavaScript be strict mode code and that it be invoked in a certain manner, substantially reduce the need for those runtime checks.
+Strict mode makes it easier to write more-"secure" JavaScript. Some websites now provide ways for users to write JavaScript that will be run by the website _on behalf of other users_. JavaScript in browsers can access the user's private information, so such JavaScript must be partially transformed before it is run, to censor access to forbidden functionality. JavaScript's flexibility makes it effectively impossible to do this without many runtime checks. Certain language functions are so pervasive that performing runtime checks has a considerable performance cost. A few strict mode tweaks, plus requiring that user-submitted JavaScript be strict mode code and that it be invoked in a certain manner, substantially reduce the need for those runtime checks.
 
-First, the value passed as `this` to a function in strict mode is not forced into being an object (a.k.a. "boxed"). For a normal function, `this` is always an object: either the provided object if called with an object-valued `this`; the value, boxed, if called with a Boolean, string, or number `this`; or the global object if called with an `undefined` or `null` `this`. (Use [`call`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call), [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply), or [`bind`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) to specify a particular `this`.) Not only is automatic boxing a performance cost, but exposing the global object in browsers is a security hazard because the global object provides access to functionality that "secure" JavaScript environments must restrict. Thus for a strict mode function, the specified `this` is not boxed into an object, and if unspecified, `this` will be `undefined`:
+First, the value passed as `this` to a function in strict mode is not forced into being an object (a.k.a. "boxed"). For a normal function, `this` is always an object: 
+
+- It is the provided object if it is called with an object-valued `this`.
+- It is the value, boxed, if it is called called with a Boolean, string, or number `this`.
+- It is the global object if it is called with an `undefined` or `null` `this`. 
+
+(Use [`call`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call), [`apply`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply), or [`bind`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) to specify a particular `this`.) Not only is automatic boxing a performance cost, but exposing the global object in browsers is a security hazard because the global object provides access to functionality that "secure" JavaScript environments must restrict. Thus, for a strict mode function, the specified `this` is not boxed into an object, and if unspecified, `this`is `undefined`:
 
 ```js
 'use strict';
@@ -289,7 +295,7 @@ console.assert(fun.call(undefined) === undefined);
 console.assert(fun.bind(true)() === true);
 ```
 
-Second, in strict mode it's no longer possible to "walk" the JavaScript stack via commonly-implemented extensions to ECMAScript. In normal code with these extensions, when a function `fun` is in the middle of being called, `fun.caller` is the function that most recently called `fun`, and `fun.arguments` is the `arguments` for that invocation of `fun`. Both extensions are problematic for "secure" JavaScript because they allow "secured" code to access "privileged" functions and their (potentially unsecured) arguments. If `fun` is in strict mode, both `fun.caller` and `fun.arguments` are non-deletable properties which throw when set or retrieved:
+Second, in strict mode it's not possible to "walk" the JavaScript stack via commonly-implemented extensions to ECMAScript. In non-strict code with these extensions, when a function `fun` is in the middle of being called, `fun.caller` is the function that most recently called `fun`, and `fun.arguments` is the `arguments` for that invocation of `fun`. Both extensions are problematic for "secure" JavaScript because they allow "secured" code to access "privileged" functions and their (potentially unsecured) arguments. If `fun` is in strict mode, both `fun.caller` and `fun.arguments` are non-deletable properties that throw errors when set or retrieved:
 
 ```js
 function restricted() {
@@ -305,13 +311,13 @@ privilegedInvoker();
 
 ## Strict mode in browsers
 
-The major browsers have fully implemented strict mode since approximately 2012, including [IE since version 10, Firefox since version 4. Chrome since version 13, etc](https://caniuse.com/use-strict). If you still support very old JS environments prior to the roll-outs of strict mode support, be careful to test any of your code that declares strict mode code to verify that its expected behaviors aren't violated when running in non-strict mode conforming JS engines.
+The major browsers have fully implemented strict mode since approximately 2012, including [IE since version 10, Firefox since version 4. Chrome since version 13, etc](https://caniuse.com/use-strict). If you still support very old JS environments that pre-date the roll-outs of strict mode support, be careful to test any of your code that declares strict mode code to verify that its expected behaviors aren't violated when running in JS engines that don't conform to strict mode.
 
-There are however some nuances to consider with how strict mode behaves in browsers.
+However, there are some nuances to consider with how strict mode behaves in browsers.
 
-Strict mode prohibits function statements that are not at the top level of a script or function. In normal mode in browsers, function statements are permitted "everywhere". _This is not part of ES5 (or even ES3)!_ It's an extension with incompatible semantics in different browsers. Note that function statements outside top level are permitted in ES2015.
+Strict mode prohibits function statements that are not at the top level of a script or function. In non-strict mode in browsers, function statements are permitted "everywhere". _This is not part of ES5 (or even ES3)!_ It's an extension with incompatible semantics in different browsers. Note that function statements outside top level are permitted in ES2015.
 
-For example, these block-level function declarations should be disallowed in strict mode by the specification's text proper:
+For example, according to the text of the specification, the following block-level function declarations should be disallowed in strict mode:
 
 ```js
 'use strict';
@@ -325,12 +331,12 @@ for (var i = 0; i < 5; i++) {
   f2();
 }
 
-function baz() { // kosher
-  function eit() { } // also kosher
+function baz() { // allowed
+  function eit() { } // also allowed
 }
 ```
 
-However, [Appendix B of the specification](https://tc39.es/ecma262/#sec-additional-ecmascript-features-for-web-browsers) recognizes *on-the-ground reality* of how code has behaved historically in the majority of JS engines/environments, particularly JS engines used by web browsers (including the engine used by Node.js). As such, while strict mode in the specification in proper restricts function declarations *not* at the top level of a script or function, [Appendix B's "Block-Level Function Declarations Web Legacy Compatibility Semantics"](https://tc39.es/ecma262/#sec-block-level-function-declarations-web-legacy-compatibility-semantics) modifies (reduces or removes) this restriction for the applicable JS environments.
+However, [Appendix B of the specification](https://tc39.es/ecma262/#sec-additional-ecmascript-features-for-web-browsers) recognizes *on-the-ground reality* of how code has behaved historically in the majority of JS engines/environments, particularly JS engines used by web browsers (including the engine used by Node.js). As such, while strict mode in the specification proper restricts function declarations *not* at the top level of a script or function, [Appendix B's "Block-Level Function Declarations Web Legacy Compatibility Semantics"](https://tc39.es/ecma262/#sec-block-level-function-declarations-web-legacy-compatibility-semantics) modifies (reduces or removes) this restriction for the applicable JS environments.
 
 ## See also
 


### PR DESCRIPTION
#### Summary
This change addresses issue #14680 by renaming example functions named "strict" to something that is not the same as the keyword being documented. I also changed some instances of functions named "f()" cuz that's just lazy. And I changed "normal mode" to "non-strict mode", though I might not have found every instance. 

And I did a bunch of copy-editing to untangle some convoluted syntax, change "which" to "that" on restrictive clauses, add clarifying words and commas, etc. 

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

